### PR TITLE
Fixed bug with comma at the front

### DIFF
--- a/Commas.java
+++ b/Commas.java
@@ -19,7 +19,7 @@ public class Commas extends ConsoleProgram {
 	private String addCommasToNumericString(String number) {
 		String newString = "";
 		for (int i = 0; i < number.length(); i++) {
-			if (((number.length() - i) % 3 == 0) && number.length() > 3)  {
+			if (((number.length() - i) % 3 == 0) && i > 1)  {
 				newString += ",";
 			}
 			newString += number.charAt(i);


### PR DESCRIPTION
Small bug in commas that put s a comma at the start of any number that is greater then 3 and a divisor of 3 i.e. If the number is 6, 9, or 12 digits long